### PR TITLE
Recover response via READ_CHAT on stream failure

### DIFF
--- a/tests/test_read_chat.py
+++ b/tests/test_read_chat.py
@@ -1,0 +1,343 @@
+"""
+Tests for GeminiClient.read_chat(cid) -- Phase A+B of response recovery.
+
+read_chat() fetches a conversation's content by cid using the GRPC.READ_CHAT
+RPC, parses the batchexecute response, finds the last assistant message, and
+returns a ModelOutput (or None on failure).
+
+All tests are expected to FAIL until read_chat() is implemented in
+GeminiClient.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+import orjson as json
+
+from gemini_webapi.client import GeminiClient
+from gemini_webapi.constants import GRPC
+from gemini_webapi.types import ModelOutput, Candidate, RPCData
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_running_client() -> GeminiClient:
+    """Create a minimal GeminiClient that appears initialized (running).
+
+    Reuses the pattern from test_retry_duplicate_conversations.py.
+    """
+    client = GeminiClient.__new__(GeminiClient)
+    client._running = True
+    client.timeout = 30
+    client.auto_close = False
+    client.close_delay = 300
+    client.auto_refresh = False
+    client.refresh_interval = 540
+    client.verbose = False
+    client.watchdog_timeout = 60
+    client._reqid = 10000
+    client.access_token = "fake_token"
+    client.build_label = None
+    client.session_id = None
+    client.cookies = MagicMock()
+    client.client = AsyncMock()
+    client.proxy = None
+    client.kwargs = {}
+    client._lock = asyncio.Lock()
+    client.close_task = None
+    client.refresh_task = None
+    client.close = AsyncMock()
+    return client
+
+
+def _build_batchexecute_response(inner_json: list) -> str:
+    """Build a realistic batchexecute response envelope.
+
+    Google's batchexecute wraps each RPC response in a JSON array where:
+      - part[0] is the RPC method identifier string (e.g. "wrb.fr")
+      - part[1] is the RPC id (e.g. "hNvQHb")
+      - part[2] is a JSON-encoded string containing the actual data
+      - remaining elements are metadata
+
+    The outer response starts with )]}\' anti-XSSI prefix and uses a
+    length-prefixed framing protocol.
+    """
+    # Build the inner part: [rpc_wrapper, rpc_id, json_encoded_body, ...]
+    inner_encoded = json.dumps(inner_json).decode("utf-8")
+    part = ["wrb.fr", "hNvQHb", inner_encoded, None, None, None, "generic"]
+    # Wrap in the outer envelope as a single-element list-of-lists
+    envelope = json.dumps([part]).decode("utf-8")
+    # Add the anti-XSSI prefix and length-prefixed frame
+    frame_len = len(envelope.encode("utf-16-le")) // 2  # UTF-16 code units
+    return f")]}}'\n\n{frame_len}\n{envelope}\n"
+
+
+def _make_mock_response(text: str) -> MagicMock:
+    """Create a mock httpx.Response with the given text."""
+    response = MagicMock()
+    response.text = text
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Verified READ_CHAT response structure (from live API testing 2026-02-24).
+#
+# After json.loads(part[2]), the inner JSON is:
+#   part_body[0][0] = conversation turn object:
+#     [0] = [cid, rid]            # metadata
+#     [1] = null
+#     [2] = [[user_text, ...]]    # user's message content
+#     [3] = assistant response object:
+#       [0] = [candidate, ...]    # candidates list
+#         candidate[0] = rcid     # reply candidate ID (e.g. "rc_...")
+#         candidate[1] = [text]   # text content at [1][0]
+#         candidate[37] = thoughts (optional, JSON string)
+#       [3] = rcid (duplicate)
+#     [4] = [timestamp, nanos]
+# ---------------------------------------------------------------------------
+
+SAMPLE_CID = "c_abc123def456"
+SAMPLE_RID = "r_f0cfdd6e03bfeea2"
+SAMPLE_RCID = "rc_reply_001"
+
+
+def _make_candidate(rcid, text):
+    """Build a candidate array matching the real Gemini structure.
+
+    In production, candidates have 38 elements. We only populate the
+    indices that read_chat() accesses: [0]=rcid, [1]=[text].
+    """
+    cand = [None] * 38
+    cand[0] = rcid
+    cand[1] = [text]
+    return cand
+
+
+# A single-turn conversation (one user message + one assistant response)
+SINGLE_TURN_INNER = [
+    [  # part_body[0] — list of conversation turns
+        [  # part_body[0][0] — single conversation turn
+            [SAMPLE_CID, SAMPLE_RID],              # [0]: metadata
+            None,                                    # [1]: null
+            [["What is 2+2?"]],                      # [2]: user message
+            [                                        # [3]: assistant response
+                [_make_candidate(SAMPLE_RCID, "The answer is 4.")],  # [0]: candidates
+            ],
+            [1771949743, 7000000],                   # [4]: timestamp
+        ],
+    ],
+]
+
+# For multi-candidate test: same structure but with a different rcid/text
+SAMPLE_CONVERSATION_INNER = [
+    [
+        [
+            [SAMPLE_CID, SAMPLE_RID],
+            None,
+            [["Tell me about Python."]],
+            [
+                [_make_candidate(SAMPLE_RCID, "Python is a versatile programming language.")],
+            ],
+            [1771949743, 7000000],
+        ],
+    ],
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestReadChatCallsBatchExecute(unittest.IsolatedAsyncioTestCase):
+    """Verify read_chat calls _batch_execute with the correct RPC and payload."""
+
+    async def test_read_chat_calls_batch_execute_with_correct_rpc(self):
+        """
+        read_chat(cid) must call _batch_execute with:
+          - GRPC.READ_CHAT as the rpcid
+          - A payload containing the cid and the correct structure:
+            json.dumps([cid, 1000, None, 1, [1], [4], None, 1])
+
+        This test mocks _batch_execute to capture its arguments and verifies
+        the RPC is constructed correctly, without caring about response parsing.
+        """
+        client = _make_running_client()
+        cid = "c_test_conversation_123"
+
+        # Mock _batch_execute to return a minimal valid-looking response
+        mock_response = _make_mock_response("")
+        client._batch_execute = AsyncMock(return_value=mock_response)
+
+        # Act -- call the method under test
+        await client.read_chat(cid)
+
+        # Assert -- _batch_execute was called exactly once
+        client._batch_execute.assert_called_once()
+
+        # Extract the RPCData from the call
+        call_args = client._batch_execute.call_args
+        payloads = call_args[0][0]  # first positional arg is list[RPCData]
+        self.assertEqual(len(payloads), 1, "Should send exactly one RPC in the batch")
+
+        rpc_data = payloads[0]
+        self.assertIsInstance(rpc_data, RPCData)
+        self.assertEqual(rpc_data.rpcid, GRPC.READ_CHAT)
+
+        # Verify the payload contains the cid in the expected structure
+        payload_parsed = json.loads(rpc_data.payload)
+        self.assertEqual(
+            payload_parsed[0], cid,
+            "First element of the READ_CHAT payload must be the conversation id"
+        )
+        # Verify the full payload structure
+        expected_payload = [cid, 1000, None, 1, [1], [4], None, 1]
+        self.assertEqual(payload_parsed, expected_payload)
+
+
+class TestReadChatReturnsModelOutput(unittest.IsolatedAsyncioTestCase):
+    """Verify read_chat returns a properly constructed ModelOutput."""
+
+    async def test_read_chat_returns_model_output_from_valid_response(self):
+        """
+        Given a realistic batchexecute response containing a conversation with
+        a single assistant reply, read_chat should return a ModelOutput with:
+          - metadata containing the cid
+          - a Candidate with the correct text and rcid
+        """
+        client = _make_running_client()
+
+        response_text = _build_batchexecute_response(SINGLE_TURN_INNER)
+        mock_response = _make_mock_response(response_text)
+        client._batch_execute = AsyncMock(return_value=mock_response)
+
+        # Act
+        result = await client.read_chat(SAMPLE_CID)
+
+        # Assert -- should return a ModelOutput, not None
+        self.assertIsNotNone(result, "read_chat should return a ModelOutput for valid responses")
+        self.assertIsInstance(result, ModelOutput)
+
+        # Verify the text content was extracted from the assistant message
+        self.assertEqual(
+            result.text, "The answer is 4.",
+            "ModelOutput.text should contain the assistant's reply text"
+        )
+
+        # Verify metadata includes the cid
+        self.assertIn(
+            SAMPLE_CID, result.metadata,
+            "ModelOutput metadata should include the conversation id"
+        )
+
+        # Verify the candidate has the correct rcid
+        self.assertEqual(len(result.candidates), 1)
+        self.assertEqual(result.candidates[0].rcid, SAMPLE_RCID)
+
+
+class TestReadChatReturnsNoneOnEmptyResponse(unittest.IsolatedAsyncioTestCase):
+    """Verify graceful degradation when response has no parseable content."""
+
+    async def test_read_chat_returns_none_on_empty_response(self):
+        """
+        When _batch_execute returns a response with no meaningful content
+        (empty body, no conversation data), read_chat should return None
+        rather than raising an exception. This supports graceful degradation
+        in the retry-recovery flow.
+        """
+        client = _make_running_client()
+
+        # An empty batchexecute response -- the inner part body is an empty list
+        response_text = _build_batchexecute_response([])
+        mock_response = _make_mock_response(response_text)
+        client._batch_execute = AsyncMock(return_value=mock_response)
+
+        # Act
+        result = await client.read_chat(SAMPLE_CID)
+
+        # Assert -- should return None, not raise
+        self.assertIsNone(
+            result,
+            "read_chat should return None when the response contains no conversation data"
+        )
+
+
+class TestReadChatReturnsNoneOnParseError(unittest.IsolatedAsyncioTestCase):
+    """Verify read_chat handles malformed responses gracefully."""
+
+    async def test_read_chat_returns_none_on_parse_error(self):
+        """
+        When _batch_execute returns garbled/unparseable text, read_chat should
+        catch the error and return None instead of letting the exception
+        propagate. This is critical for the recovery path -- if reading the
+        chat fails, we fall back to returning None rather than crashing.
+        """
+        client = _make_running_client()
+
+        # Completely garbled response that will fail JSON parsing
+        mock_response = _make_mock_response("this is not valid json at all {{{")
+        client._batch_execute = AsyncMock(return_value=mock_response)
+
+        # Act -- should NOT raise any exception
+        result = await client.read_chat(SAMPLE_CID)
+
+        # Assert
+        self.assertIsNone(
+            result,
+            "read_chat should return None when response parsing fails, not raise"
+        )
+
+    async def test_read_chat_returns_none_when_batch_execute_raises(self):
+        """
+        If _batch_execute itself raises an exception (network error, auth
+        failure, etc.), read_chat should catch it and return None.
+        """
+        client = _make_running_client()
+        client._batch_execute = AsyncMock(side_effect=Exception("Network timeout"))
+
+        result = await client.read_chat(SAMPLE_CID)
+
+        self.assertIsNone(
+            result,
+            "read_chat should return None when _batch_execute raises an exception"
+        )
+
+
+class TestReadChatExtractsFromConversationStructure(unittest.IsolatedAsyncioTestCase):
+    """Verify read_chat correctly navigates the nested conversation structure."""
+
+    async def test_read_chat_extracts_from_conversation_turn(self):
+        """
+        The READ_CHAT response contains a conversation turn with the assistant's
+        response nested at turn[3][0][candidate]. Verify read_chat navigates
+        this structure and extracts the correct text and rcid.
+        """
+        client = _make_running_client()
+
+        response_text = _build_batchexecute_response(SAMPLE_CONVERSATION_INNER)
+        mock_response = _make_mock_response(response_text)
+        client._batch_execute = AsyncMock(return_value=mock_response)
+
+        # Act
+        result = await client.read_chat(SAMPLE_CID)
+
+        # Assert
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ModelOutput)
+
+        self.assertEqual(
+            result.text,
+            "Python is a versatile programming language.",
+            "read_chat must extract the assistant's response text from the conversation turn"
+        )
+        self.assertEqual(
+            result.candidates[0].rcid,
+            SAMPLE_RCID,
+            "The rcid should be extracted from the candidate structure"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_read_chat.py
+++ b/tests/test_read_chat.py
@@ -2,11 +2,8 @@
 Tests for GeminiClient.read_chat(cid) -- Phase A+B of response recovery.
 
 read_chat() fetches a conversation's content by cid using the GRPC.READ_CHAT
-RPC, parses the batchexecute response, finds the last assistant message, and
-returns a ModelOutput (or None on failure).
-
-All tests are expected to FAIL until read_chat() is implemented in
-GeminiClient.
+RPC, parses the batchexecute response, extracts the latest assistant message,
+and returns a ModelOutput (or None on failure).
 """
 
 import asyncio

--- a/tests/test_retry_duplicate_conversations.py
+++ b/tests/test_retry_duplicate_conversations.py
@@ -1,0 +1,353 @@
+"""
+Tests for the retry-abort guard that prevents duplicate conversations when
+a ChatSession's cid gets assigned mid-stream and then an APIError triggers
+a retry via the @running decorator.
+
+These tests define the expected behavior for the fix described in the bug report:
+when _generate() is retried after an APIError, and the ChatSession started with
+an empty cid but now has a truthy cid (assigned by Gemini mid-stream), the retry
+should be aborted by raising GeminiError (which the @running decorator does NOT
+catch) instead of allowing a duplicate conversation to be created.
+
+All tests are expected to FAIL until the guard logic is implemented in
+GeminiClient._generate().
+"""
+
+import asyncio
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gemini_webapi.client import GeminiClient, ChatSession
+from gemini_webapi.exceptions import APIError, GeminiError
+
+
+def _make_running_client() -> GeminiClient:
+    """Create a minimal GeminiClient that appears initialized (running).
+
+    The client is configured so the @running decorator sees _running=True
+    and does not attempt real initialization. The close() method is mocked
+    as a no-op to prevent _running from being flipped to False during the
+    status-500 error path in _generate().
+    """
+    client = GeminiClient.__new__(GeminiClient)
+    # Attributes required by the @running decorator
+    client._running = True
+    client.timeout = 30
+    client.auto_close = False
+    client.close_delay = 300
+    client.auto_refresh = False
+    client.refresh_interval = 540
+    client.verbose = False
+    client.watchdog_timeout = 60
+    # Attributes required by _generate() internals
+    client._reqid = 10000
+    client.access_token = "fake_token"
+    client.build_label = None
+    client.session_id = None
+    client.cookies = MagicMock()
+    client.client = AsyncMock()
+    client.proxy = None
+    client.kwargs = {}
+    client._lock = asyncio.Lock()
+    client.close_task = None
+    client.refresh_task = None
+    # Mock close() as a no-op so _running stays True across retries.
+    # In production, close() sets _running=False, which would cause the
+    # decorator to call init() -- requiring real auth cookies.
+    client.close = AsyncMock()
+    return client
+
+
+def _make_chat_session(client: GeminiClient, cid: str = "") -> ChatSession:
+    """Create a ChatSession with the given initial cid."""
+    chat = ChatSession.__new__(ChatSession)
+    # Manually initialize the private metadata list (matches ChatSession.__init__)
+    chat._ChatSession__metadata = [
+        cid, "", "", None, None, None, None, None, None, ""
+    ]
+    chat.geminiclient = client
+    chat.last_output = None
+    chat.model = "unspecified"
+    chat.gem = None
+    return chat
+
+
+def _make_fail_stream(status_code=500, on_enter=None):
+    """Return a callable that produces async context managers simulating a
+    failed HTTP stream response.
+
+    Parameters
+    ----------
+    status_code : int
+        The HTTP status code the mock response will report.
+    on_enter : callable or None
+        Optional side-effect function called each time the stream context
+        is entered (useful for mutating chat.cid mid-stream).
+    """
+    mock_response = AsyncMock()
+    mock_response.status_code = status_code
+
+    class _FailStreamCtx:
+        async def __aenter__(self_ctx):
+            if on_enter is not None:
+                on_enter()
+            return mock_response
+
+        async def __aexit__(self_ctx, *args):
+            pass
+
+    def stream_factory(*args, **kwargs):
+        return _FailStreamCtx()
+
+    return stream_factory
+
+
+class TestRetryAbortOnCidAssignedMidstream(unittest.IsolatedAsyncioTestCase):
+    """
+    When a ChatSession starts with an empty cid, Gemini may return metadata
+    that assigns a real cid during the first attempt of _generate(). If an
+    APIError then occurs and the @running decorator retries, the guard in
+    _generate() must detect the cid was empty at the start but is now truthy,
+    and raise GeminiError to abort the retry -- preventing a duplicate
+    conversation.
+    """
+
+    async def test_retry_aborts_when_cid_assigned_midstream(self):
+        """
+        Scenario:
+          1. ChatSession starts with cid="" (new conversation).
+          2. During the first call to _generate(), the HTTP response returns
+             status 500. Before the APIError is raised, the close() side-effect
+             simulates Gemini having assigned a cid (as would happen at line 692
+             if some metadata arrived before the stream broke).
+          3. The @running decorator catches APIError and retries _generate().
+          4. On retry entry, the guard should detect that original_cid was ""
+             but chat.cid is now truthy, and raise GeminiError to abort.
+
+        Expected: GeminiError is raised (not APIError), aborting the retry
+        and preventing a duplicate conversation on Gemini's web UI.
+        """
+        client = _make_running_client()
+        chat = _make_chat_session(client, cid="")
+
+        # Verify precondition
+        self.assertEqual(chat.cid, "")
+
+        session_state = {
+            "last_texts": {},
+            "last_thoughts": {},
+            "last_progress_time": time.time(),
+        }
+
+        stream_call_count = 0
+
+        def on_stream_enter():
+            """Side-effect: on the first stream entry, simulate Gemini having
+            assigned a cid via metadata before the stream broke."""
+            nonlocal stream_call_count
+            stream_call_count += 1
+            if stream_call_count == 1:
+                # Simulates what happens at line 692 when Gemini returns
+                # metadata with a conversation id before the stream fails.
+                chat.cid = "c_abc123_assigned_midstream"
+
+        client.client.stream = _make_fail_stream(
+            status_code=500, on_enter=on_stream_enter
+        )
+
+        # The flow:
+        # 1. _generate() enters, should save original_cid="" in session_state
+        # 2. Stream returns 500 -> calls self.close() (mocked no-op) -> APIError
+        # 3. @running catches APIError, retries with same session_state + kwargs
+        # 4. _generate() re-enters. Guard checks: original_cid=="" but
+        #    chat.cid="c_abc123_assigned_midstream" -> raises GeminiError
+        # 5. GeminiError is NOT caught by @running -> propagates to caller
+        with patch("gemini_webapi.utils.decorators.DELAY_FACTOR", 0):
+            with self.assertRaises(GeminiError) as ctx:
+                async for _ in client._generate(
+                    prompt="test prompt",
+                    chat=chat,
+                    session_state=session_state,
+                ):
+                    pass
+
+        self.assertIn(
+            "duplicate",
+            str(ctx.exception).lower(),
+            "GeminiError message should mention duplicate conversation prevention",
+        )
+        # The guard should have fired on the 2nd call, meaning stream was
+        # only entered once (the first call).
+        self.assertEqual(stream_call_count, 1,
+            "Stream should only be entered once; the retry should be aborted "
+            "before reaching the HTTP call.")
+
+
+class TestRetryProceedsWhenCidAlreadySet(unittest.IsolatedAsyncioTestCase):
+    """
+    When a ChatSession already has a cid before _generate() is called
+    (continuing an existing conversation), an APIError should NOT abort the
+    retry -- the cid was already set, so retrying won't create a duplicate.
+    """
+
+    async def test_retry_proceeds_when_cid_was_already_set(self):
+        """
+        Scenario:
+          1. ChatSession starts with cid="c_existing_123" (existing conversation).
+          2. Every call to _generate() hits status 500 -> APIError.
+          3. The @running decorator retries until retries are exhausted.
+          4. The guard should NOT intervene because original_cid was truthy.
+
+        Expected: APIError is raised after all retries are exhausted
+        (not GeminiError), proving the guard allowed normal retry behavior.
+        """
+        client = _make_running_client()
+        chat = _make_chat_session(client, cid="c_existing_123")
+
+        session_state = {
+            "last_texts": {},
+            "last_thoughts": {},
+            "last_progress_time": time.time(),
+        }
+
+        stream_call_count = 0
+
+        def count_stream_entries():
+            nonlocal stream_call_count
+            stream_call_count += 1
+
+        client.client.stream = _make_fail_stream(
+            status_code=500, on_enter=count_stream_entries
+        )
+
+        with patch("gemini_webapi.utils.decorators.DELAY_FACTOR", 0):
+            with self.assertRaises(APIError):
+                async for _ in client._generate(
+                    prompt="test prompt",
+                    chat=chat,
+                    session_state=session_state,
+                ):
+                    pass
+
+        # With retry=5 and the original call, we expect 6 total stream entries
+        # (1 original + 5 retries). All should proceed because cid was already set.
+        self.assertGreater(stream_call_count, 1,
+            "Multiple stream attempts should occur when cid was already set, "
+            "proving the guard did not abort retries.")
+
+
+class TestRetryProceedsWhenNoChatSession(unittest.IsolatedAsyncioTestCase):
+    """
+    When _generate() is called without a ChatSession (chat=None), the guard
+    logic should not interfere -- there is no ChatSession to track, so retries
+    should proceed normally.
+    """
+
+    async def test_retry_proceeds_when_no_chat_session(self):
+        """
+        Scenario:
+          1. _generate() is called with chat=None (standalone generation).
+          2. Every call hits status 500 -> APIError.
+          3. The @running decorator retries until exhausted.
+          4. The guard should NOT intervene (no ChatSession).
+
+        Expected: APIError is raised after all retries (not GeminiError).
+        """
+        client = _make_running_client()
+
+        session_state = {
+            "last_texts": {},
+            "last_thoughts": {},
+            "last_progress_time": time.time(),
+        }
+
+        stream_call_count = 0
+
+        def count_stream_entries():
+            nonlocal stream_call_count
+            stream_call_count += 1
+
+        client.client.stream = _make_fail_stream(
+            status_code=500, on_enter=count_stream_entries
+        )
+
+        with patch("gemini_webapi.utils.decorators.DELAY_FACTOR", 0):
+            with self.assertRaises(APIError):
+                async for _ in client._generate(
+                    prompt="test prompt",
+                    chat=None,
+                    session_state=session_state,
+                ):
+                    pass
+
+        # Should have multiple stream attempts (no guard to abort).
+        self.assertGreater(stream_call_count, 1,
+            "Multiple stream attempts should occur when chat=None, "
+            "proving the guard did not interfere.")
+
+
+class TestSessionStateTracksOriginalCid(unittest.IsolatedAsyncioTestCase):
+    """
+    Verify that session_state["original_cid"] is set on first entry to
+    _generate() and preserved across retries. This is the foundational
+    mechanism for the duplicate-conversation guard.
+    """
+
+    async def test_session_state_tracks_original_cid(self):
+        """
+        Scenario:
+          1. A ChatSession starts with cid="" (new conversation).
+          2. session_state is passed to _generate().
+          3. On first entry, _generate() should set
+             session_state["original_cid"] = "" (the current chat.cid).
+          4. Even after _generate() raises and retries, session_state should
+             still contain "original_cid" == "".
+
+        Expected: After _generate() completes (even with failure),
+        session_state contains "original_cid" set to the chat.cid value
+        from the very first entry.
+        """
+        client = _make_running_client()
+        chat = _make_chat_session(client, cid="")
+
+        session_state = {
+            "last_texts": {},
+            "last_thoughts": {},
+            "last_progress_time": time.time(),
+        }
+
+        # Verify precondition: no original_cid key yet
+        self.assertNotIn("original_cid", session_state)
+
+        client.client.stream = _make_fail_stream(status_code=500)
+
+        with patch("gemini_webapi.utils.decorators.DELAY_FACTOR", 0):
+            try:
+                async for _ in client._generate(
+                    prompt="test prompt",
+                    chat=chat,
+                    session_state=session_state,
+                ):
+                    pass
+            except (APIError, GeminiError):
+                pass  # Expected -- we just want to inspect session_state
+
+        # The critical assertion: session_state should now contain original_cid.
+        # This will FAIL because _generate() does not yet track original_cid.
+        self.assertIn(
+            "original_cid",
+            session_state,
+            "session_state must track 'original_cid' to detect cid changes "
+            "across retries. This key should be set on first entry to _generate().",
+        )
+        self.assertEqual(
+            session_state["original_cid"],
+            "",
+            "original_cid should be the empty string that chat.cid had when "
+            "_generate() was first entered.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `read_chat(cid)` method to `GeminiClient` that fetches a conversation's completed response via `GRPC.READ_CHAT`
- Modify the retry guard in `_generate()` to attempt response recovery before raising `GeminiError` when a stream fails after Gemini assigns a cid mid-stream
- Previously, this scenario raised an error telling the user to check Gemini web UI; now it transparently recovers the response

## Details

When `_generate()` fails after Gemini assigns a `cid` (meaning Gemini created the conversation and likely completed the response server-side), the guard now:
1. Attempts `read_chat(chat.cid)` to fetch the completed response
2. If successful, yields the recovered `ModelOutput` (no error, no retry)
3. If recovery fails, raises `GeminiError` as before

The `READ_CHAT` response structure was verified against the live Gemini API. The candidate format matches `StreamGenerate` (`candidate[0]=rcid`, `candidate[1][0]=text`).

## Test plan

- [x] 6 unit tests for `read_chat()` (RPC call, parsing, graceful degradation)
- [x] 3 unit tests for recovery guard (success yields output, failure raises error, exception raises error)
- [x] 4 existing guard tests still pass (no regressions)
- [x] Live API verification against real conversation (`c_13221e5ebe55bdf2`)